### PR TITLE
Add README.md for project introduction and guidelines

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="TypeScriptCompiler">
+    <option name="nodeInterpreterTextField" value="$PROJECT_DIR$/../../../../../../../Program Files/nodejs/node" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Filo
+
+Filo is a light frontend library that facilitates communication between different parts of a browser extension.
+
+This repository is a monorepo that contains two libraries, namely filo and filo-react. The latter library provides a set
+of useful React hooks that encapsulate the functionality of the filo client.
+
+```
+/core       @foxstack/filo
+/react-hook @foxstack/filo-react-hook
+/examples   a collection of examples used to validate the functionality of the aforementioned libraries.
+```
+
+## Usage
+
+Check examples.
+
+# Contributing
+
+`cd` to the lib dir and run the scripts there. Some useful scripts are listed here:
+
+```bash
+# Delete the output directory and rebuild the package.
+pnpm run clean:build
+```


### PR DESCRIPTION
This commit provides a new README.md outlining the project's scope and structure. It introduces the monorepo containing two libraries, offers basic usage instructions, and establishes initial contribution guidelines.

close #1.